### PR TITLE
Update Check Zone Peer API register prerequisite

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2020-01-01/subscriptions.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2020-01-01/subscriptions.json
@@ -189,7 +189,7 @@
           "Subscriptions"
         ],
         "operationId": "Subscriptions_CheckZonePeers",
-        "description": "Compares a subscriptions logical zone mapping",
+        "description": "Compares a subscriptions logical zone mapping. Please [register the feature](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/preview-features?tabs=azure-cli#register-preview-feature) 'AvailabilityZonePeering' with namespace 'Microsoft.Resources', and check the status before calling the checkZonePeers API. Example of AZ CLI: 'az feature register -n AvailabilityZonePeering --namespace Microsoft.Resources', and check the status with 'az feature show -n AvailabilityZonePeering --namespace Microsoft.Resources' before calling the api. ",
         "parameters": [
           {
             "$ref": "#/parameters/SubscriptionIdParameter"


### PR DESCRIPTION
I'm Penny Ko in MSFT.
I'm trying to add below prerequisite to this doc https://learn.microsoft.com/en-us/rest/api/resources/subscriptions/check-zone-peers . People will get 404 error message without registering it.

Please register the feature 'AvailabilityZonePeering' with namespace 'Microsoft.Resources', and check the status before calling the checkZonePeers API. Example of AZ CLI: 'az feature register -n AvailabilityZonePeering --namespace Microsoft.Resources', and check the status with 'az feature show -n AvailabilityZonePeering --namespace Microsoft.Resources' .

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
