### PR TITLE
Update subscriptions.json Add necessary prerequisite to register checkZonePeers API

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/stable/2020-01-01/subscriptions.json
+++ b/specification/resources/resource-manager/Microsoft.Resources/stable/2020-01-01/subscriptions.json
@@ -189,7 +189,7 @@
           "Subscriptions"
         ],
         "operationId": "Subscriptions_CheckZonePeers",
-        "description": "Compares a subscriptions logical zone mapping",
+        "description": "Compares a subscriptions logical zone mapping. Please register the feature with AZ CLI: 'az feature register -n AvailabilityZonePeering --namespace Microsoft.Resources' , and check the status with: 'az feature show -n AvailabilityZonePeering --namespace Microsoft.Resources' before calling the checkZonePeers API.",
         "parameters": [
           {
             "$ref": "#/parameters/SubscriptionIdParameter"


### PR DESCRIPTION
Add necessary prerequisite to register checkZonePeers API. 
Customer can't use this checkZonePeers API https://learn.microsoft.com/en-us/rest/api/resources/subscriptions/check-zone-peers without registering, but there was no information about the prerequisite. 

Please register the feature with AZ CLI: 'az feature register -n AvailabilityZonePeering --namespace Microsoft.Resources' , and check the status with: 'az feature show -n AvailabilityZonePeering --namespace Microsoft.Resources' before calling the checkZonePeers API.",

They will get the error message if they didn't register as above. 
Error message: "The resource type could not be found in the namespace 'Microsoft.Resources' for api version '2022-12-01'."

This info was being merged in https://github.com/Azure/azure-rest-api-specs/pull/22623 but don't know why the information was gone again.
I'm a MSFT employee Penny Ko, please don't hesitate to reach out to me if you have any questions related to this. Thanks!

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
